### PR TITLE
Adds a shortcut to context params

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ end
 
 The `expects` block defines the expectations: the expected attributes of the
 context prior to the interactor running, along with any predicates that further
-constrain the input.
+constrain the input. Also as you define expectations you gain a shortcut to 
+context params, so instead of `context.email` you can use just `email` to 
+access the param `if user = User.authenticate(email, password)`.
 
 The `assures` block defines the assurances: the expected attributes of the
 context after the interactor runs and successfully completes, along with any

--- a/lib/interactor/contracts.rb
+++ b/lib/interactor/contracts.rb
@@ -2,6 +2,7 @@ require "dry-validation"
 require "interactor"
 require "interactor/contracts/dsl"
 require "interactor/contracts/errors"
+require "interactor/contracts/forwarder"
 
 module Interactor
   # Create a contract for your interactor that specifies what it expects as
@@ -17,6 +18,7 @@ module Interactor
         fail NotAnInteractor, "#{descendant} does not include `Interactor'"
       end
       descendant.extend(DSL)
+      descendant.extend(Forwarder)
     end
 
     private

--- a/lib/interactor/contracts/dsl.rb
+++ b/lib/interactor/contracts/dsl.rb
@@ -73,6 +73,7 @@ module Interactor
       def expects(&block)
         contract.add_expectation(&block)
         define_expectations_hook
+        def_delegates_to_context(contract.expectations.keys)
       end
 
       # Defines a consequence that is called when a contract is breached

--- a/lib/interactor/contracts/forwarder.rb
+++ b/lib/interactor/contracts/forwarder.rb
@@ -1,0 +1,21 @@
+module Interactor
+  module Contracts
+    module Forwarder
+      def self.extended(descendant)
+        descendant.extend(Forwardable) unless self.using_activesupport?
+      end
+
+      def def_delegates_to_context(keys)
+        if Forwarder.using_activesupport?
+          delegate *keys, to: :context
+        else
+          def_delegators :context, *keys
+        end
+      end
+
+      def self.using_activesupport?
+        @using_activesupport ||= !!defined?(ActiveSupport)
+      end
+    end
+  end
+end

--- a/lib/interactor/contracts/forwarder.rb
+++ b/lib/interactor/contracts/forwarder.rb
@@ -1,10 +1,21 @@
 module Interactor
   module Contracts
+    # Enables a forwarding to context.params to avoid boilerplate code like `context.param`
     module Forwarder
-      def self.extended(descendant)
-        descendant.extend(Forwardable) unless self.using_activesupport?
+      # Called when the module is extended
+      #
+      # @api private
+      # @param [Module] extended
+      # @return [void]
+      def self.extended(extended)
+        extended.extend(Forwardable) unless Forwarder.using_activesupport?
       end
 
+      # Define delegates from all expectations to context object
+      #
+      # @api private
+      # @params [Array] all attributes keys defined in expects block
+      # @return [void]
       def def_delegates_to_context(keys)
         if Forwarder.using_activesupport?
           delegate *keys, to: :context
@@ -13,8 +24,12 @@ module Interactor
         end
       end
 
+      # Checks whether ActiveSupport is being used or not
+      #
+      # @api private
+      # @return [Boolean] whether ActiveSupport is being used or not
       def self.using_activesupport?
-        @using_activesupport ||= !!defined?(ActiveSupport)
+        !!defined?(ActiveSupport)
       end
     end
   end

--- a/lib/interactor/contracts/terms.rb
+++ b/lib/interactor/contracts/terms.rb
@@ -46,6 +46,23 @@ module Interactor
       def call(context)
         Outcome.new(@terms.new.call(context.to_h))
       end
+
+      # Returns all properties defined in add
+      #
+      # @example
+      #   terms = Interactor::Contracts::Terms.new
+      #   terms.add do
+      #     required(:name).filled
+      #     required(:email).filled
+      #   end
+      #   puts terms.keys
+      #   [:name, :email]
+      #
+      # @api public
+      # @return [Array]
+      def keys
+        @terms.new.rules.keys
+      end
     end
   end
 end

--- a/spec/interactor/contracts_spec.rb
+++ b/spec/interactor/contracts_spec.rb
@@ -119,6 +119,26 @@ RSpec.describe Interactor::Contracts do
   end
 
   describe ".expects" do
+    it "delegates all params to context" do
+      interactor = Class.new do
+        include Interactor
+        include Interactor::Contracts
+
+        expects do
+          required(:dwarf).filled
+        end
+
+        def call
+          context.output = dwarf.name
+        end
+      end
+
+      result = interactor.call(dwarf: OpenStruct.new(name: "Thorin Escudo de Carvalho"))
+
+      expect(result).to be_a_success
+      expect(result.output).to eq("Thorin Escudo de Carvalho")
+    end
+
     it "creates and uses a schema to validate inputs" do
       interactor = Class.new do
         include Interactor


### PR DESCRIPTION
Hi @michaelherold I just created a new little feature to the project, the idea here is being able to get rid off codes like `context.params`, instead we can simply call `params` and it would be delegated to context since user had declared the attribute in a `expects` block.