### PR TITLE
Fix breach set #to_h for nested schema

### DIFF
--- a/lib/interactor/contracts/breach_set.rb
+++ b/lib/interactor/contracts/breach_set.rb
@@ -36,7 +36,12 @@ module Interactor
       # @return [Hash] a hash with property keys and message values
       def to_hash
         reduce({}) do |result, (property, messages)|
-          result[property] = Array(result[property]) | messages
+          result[property] = if messages.is_a?(Hash)
+                               messages
+                             else
+                               Array(result[property]) | messages
+                             end
+
           result
         end
       end

--- a/spec/interactor/contracts/breach_set_spec.rb
+++ b/spec/interactor/contracts/breach_set_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Interactor::Contracts::BreachSet do
         breach.call(:first_name, ["first"]),
         breach.call(:first_name, %w(second third)),
         breach.call(:last_name, ["last_name is missing"]),
+        breach.call(:address, "line_1" => "line 1 is missing"),
       ]
 
       set = Interactor::Contracts::BreachSet.new(breaches)
@@ -19,6 +20,7 @@ RSpec.describe Interactor::Contracts::BreachSet do
 
       expect(result[:first_name]).to eq(%w(first second third))
       expect(result[:last_name]).to eq(["last_name is missing"])
+      expect(result[:address]).to eq("line_1" => "line 1 is missing")
     end
   end
 end


### PR DESCRIPTION
#to_h should set the messages as hash instead of array if message is a hash

fixes #11 