### PR TITLE
Add support for I18n without Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
-* Your contribution here.
+* [#21](https://github.com/michaelherold/interactor-contracts/pull/21): Add support for I18n without the use of Rails - [@noelrocha](https://github.com/noelrocha).
 
 ### Changed
 

--- a/lib/interactor/contracts/terms.rb
+++ b/lib/interactor/contracts/terms.rb
@@ -16,6 +16,9 @@ module Interactor
       # @param [Dry::Validation::Schema] terms the terms to start with
       def initialize(terms = Class.new(Dry::Validation::Schema))
         @terms = terms
+        @terms.configure do |config|
+          config.messages = :i18n
+        end
       end
 
       # Add a new set of terms to the list of terms


### PR DESCRIPTION
This add support for I18n, respecting dry-validation configurations

Closes #20