### PR TITLE
Fix the Travis configuration for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: ruby
 rvm:
   - 2.4
   - 2.5
-  - 2.6
-  - jruby-head
   - ruby-head
 script: bundle exec rspec
 sudo: false
@@ -20,11 +18,10 @@ matrix:
     - rvm: 2.6
       before_script:
         - bundle exec danger
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
       after_script:
-        - bundle exec codeclimate-test-reporter
-    - rvm: jruby-9.1.5.0
-      env: JRUBY_OPTS=''
-
-addons:
-  code_climate:
-    repo_token: 4c8d32857f6271a921d0db0bdf9a316c47b5cc89827c85da862ab2738842dbb1
+        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+    - rvm: jruby-9.2.8.0
+      jdk: openjdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project will be documented in this file. This projec
 ### Miscellaneous
 
 * [#24](https://github.com/michaelherold/interactor-contracts/pull/24): Fixed a typo in the gem specification - [@bittersweet](https://github.com/bittersweet).
+* [#28](https://github.com/michaelherold/interactor-contracts/pull/28): Fixed
+the Travis configuration to stop failing on JRuby builds - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## [0.2.0] - 2019-05-27

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :development, :test do
 end
 
 group :test do
-  gem 'codeclimate-test-reporter', require: false
   gem 'danger-changelog', require: false
   gem 'danger-commit_lint', require: false
   gem 'danger-rubocop', require: false

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ versions:
 * Ruby 2.4
 * Ruby 2.5
 * Ruby 2.6
-* JRuby 9.1
+* JRuby 9.2
 
 If something doesn't work on one of these versions, it's a bug.
 


### PR DESCRIPTION
JRuby and the Java matrix is causing failures from the test suite. This
isn't acceptable so we have to fix it.