### PR TITLE
Rename the `assures` method to `promises`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changed
 
-* Your contribution here.
+* [#29](https://github.com/michaelherold/interactor-contracts/pull/29): Renamed the `assures` method to `promises` and all of the internals to reflect the new naming. This is a backward-compatible change due to an alias of `assures` to `promises` - [@michaelherold](https://github.com/michaelherold), suggested by [@KelseyDH](https://github.com/KelseyDH).
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [travis]: https://travis-ci.org/michaelherold/interactor-contracts
 
 Interactor::Contracts is an extension to the [interactor] gem that gives you
-the ability to specify the expectations (expected inputs) and assurances
+the ability to specify the expectations (expected inputs) and promises
 (expected outputs) of your interactors.
 
 [interactor]: https://github.com/collectiveidea/interactor
@@ -33,7 +33,7 @@ Or install it yourself as:
 ## Usage
 
 Let's extend the sample `AuthenticateUser` from the Interactor examples with a
-contract that specifies its expectations and assurances.
+contract that specifies its expectations and promises.
 
 ```ruby
 class AuthenticateUser
@@ -45,7 +45,7 @@ class AuthenticateUser
     required(:password).filled
   end
 
-  assures do
+  promises do
     required(:user).filled
     required(:token).filled
   end
@@ -69,19 +69,20 @@ The `expects` block defines the expectations: the expected attributes of the
 context prior to the interactor running, along with any predicates that further
 constrain the input.
 
-The `assures` block defines the assurances: the expected attributes of the
+The `promises` block defines the promises: the expected attributes of the
 context after the interactor runs and successfully completes, along with any
-predicates the further constrain the output.
+predicates the further constrain the output. Note, for backward-compatibility,
+this is also available via the `assures` method.
 
 Because interactors can have transitive dependencies through the use of
 organizers, any other inputs or outputs are ignored from the perspective of
 the contract and are passed along to the outgoing (successful) context.
 
-Both `expects` and `assures` wrap [dry-validation], so you can use any
+Both `expects` and `promises` wrap [dry-validation], so you can use any
 predicates defined in it to describe the expected inputs and outputs of your
 interactor.
 
-To hook into a failed expectation or assurance, you can use the `on_breach`
+To hook into a failed expectation or promise, you can use the `on_breach`
 method to defined a breach handler. It should take a 1-arity block that expects
 an array of `Breach` objects. These objects have a `property` attribute that
 will give you the key that's in breach of its contract. Breaches also have a

--- a/lib/interactor/contracts/breach_set.rb
+++ b/lib/interactor/contracts/breach_set.rb
@@ -18,7 +18,7 @@ module Interactor
       #       required(:password).filled
       #     end
       #
-      #     assures do
+      #     promises do
       #       required(:user).filled
       #       required(:token).filled
       #     end

--- a/lib/interactor/contracts/contract.rb
+++ b/lib/interactor/contracts/contract.rb
@@ -4,7 +4,7 @@ require 'interactor/contracts/terms'
 
 module Interactor
   module Contracts
-    # Contains the assurances, expectations, and consequences of an
+    # Contains the promises, expectations, and consequences of an
     # interactor's contract.
     class Contract
       # Instantiates a new Contract with the given constraints
@@ -13,26 +13,26 @@ module Interactor
       #   Interactor::Contracts::Contract.new
       #
       # @api semipublic
-      # @param [Terms] assurances the Contract's assurances
+      # @param [Terms] promises the Contract's promises
       # @param [Terms] expectations the Contract's expectations
       # @param [Array<#call>] consequences the Contract's consequences
       # rubocop:disable Metrics/LineLength
-      def initialize(assurances: Terms.new, expectations: Terms.new, consequences: [])
-        @assurances = assurances
+      def initialize(promises: Terms.new, expectations: Terms.new, consequences: [])
+        @promises = promises
         @consequences = consequences
         @expectations = expectations
       end
       # rubocop:enable Metrics/LineLength
 
-      # The assurances the Contract will fulfill
+      # The promises the Contract will fulfill
       #
       # @example
       #   contract = Interactor::Contracts::Contract.new
-      #   contract.assurances  #=> <#Interactor::Contracts::Terms>
+      #   contract.promises  #=> <#Interactor::Contracts::Terms>
       #
       # @api semipublic
-      # @return [Terms] the terms for the assurances
-      attr_reader :assurances
+      # @return [Terms] the terms for the promises
+      attr_reader :promises
 
       # The expectations for arguments passed into the Interactor
       #
@@ -44,19 +44,19 @@ module Interactor
       # @return [Terms] the terms for the expectations
       attr_reader :expectations
 
-      # Adds an assurance to the Contract's set of assurances
+      # Adds an promise to the Contract's set of promises
       #
       # @example
       #   contract = Interactor::Contracts::Contract.new
-      #   contract.add_assurance do
+      #   contract.add_promise do
       #     required(:name).filled
       #   end
       #
       # @api semipublic
-      # @param [Block] term the assurance as a block of arity 0
+      # @param [Block] term the promise as a block of arity 0
       # @return [void]
-      def add_assurance(&term)
-        assurances.add(&term)
+      def add_promise(&term)
+        promises.add(&term)
       end
 
       # Adds a consequence to the Contract's set of consequences

--- a/lib/interactor/contracts/dsl.rb
+++ b/lib/interactor/contracts/dsl.rb
@@ -6,14 +6,14 @@ module Interactor
   module Contracts
     # Defines the class-level DSL that enables Interactor contracts.
     module DSL
-      # Defines the assurances of an Interactor and creates an after hook
+      # Defines the promises of an Interactor and creates an after hook
       #
       # @example
       #   class CreatePerson
       #     include Interactor
       #     include Interactor::Contracts
       #
-      #     assures do
+      #     promises do
       #       required(:person).filled
       #     end
       #
@@ -23,12 +23,13 @@ module Interactor
       #   end
       #
       # @api public
-      # @param [Block] block the block defining the assurances
+      # @param [Block] block the block defining the promises
       # @return [void]
-      def assures(&block)
-        contract.add_assurance(&block)
-        define_assurances_hook
+      def promises(&block)
+        contract.add_promise(&block)
+        define_promises_hook
       end
+      alias assures promises
 
       # The Contract to enforce on calls to the Interactor
       #
@@ -37,7 +38,7 @@ module Interactor
       #     include Interactor
       #     include Interactor::Contracts
       #
-      #     assures do
+      #     promises do
       #       required(:person).filled
       #     end
       #
@@ -78,18 +79,18 @@ module Interactor
       end
 
       # Sets contract to given one and calls hooks
-      # define_assurances_hook and define_expectations_hook
+      # define_promises_hook and define_expectations_hook
       #
       # @api semipublic
       # @param [Contract] contract
       # @return [void]
       def inherit_contract(contract)
         @contract = Contract.new(
-          assurances: contract.assurances.clone,
+          promises: contract.promises.clone,
           expectations: contract.expectations.clone,
           consequences: contract.consequences.clone
         )
-        define_assurances_hook
+        define_promises_hook
         define_expectations_hook
       end
 
@@ -124,12 +125,12 @@ module Interactor
 
       private
 
-      # Flags whether the assurances hook has been defined
+      # Flags whether the promises hook has been defined
       #
       # @api private
       # @return [TrueClass, FalseClass] true if the hook is defined
-      attr_reader :defined_assurances_hook
-      alias defined_assurances_hook? defined_assurances_hook
+      attr_reader :defined_promises_hook
+      alias defined_promises_hook? defined_promises_hook
 
       # Flags whether the expectations hook has been defined
       #
@@ -143,12 +144,12 @@ module Interactor
       # @api private
       # @raise [Interactor::Failure] if the input fails to meet its contract.
       # @return [void]
-      def define_assurances_hook
-        return if defined_assurances_hook?
+      def define_promises_hook
+        return if defined_promises_hook?
 
-        after { enforce_contracts(contract.assurances) }
+        after { enforce_contracts(contract.promises) }
 
-        @defined_assurances_hook = true
+        @defined_promises_hook = true
       end
 
       # Defines a before hook that validates the Interactor's input

--- a/lib/interactor/contracts/terms.rb
+++ b/lib/interactor/contracts/terms.rb
@@ -4,7 +4,7 @@ require 'interactor/contracts/outcome'
 
 module Interactor
   module Contracts
-    # The terms of a contract, either for assurances or expectations
+    # The terms of a contract, either for promises or expectations
     class Terms
       # Instantiates a new set of terms
       #

--- a/spec/interactor/contracts/dsl_spec.rb
+++ b/spec/interactor/contracts/dsl_spec.rb
@@ -97,7 +97,31 @@ RSpec.describe Interactor::Contracts::DSL do
     end
   end
 
-  describe '.assures' do
+  describe '.assures (backwards compatibility)' do
+    let(:klass) do
+      Class.new do
+        include Interactor
+        include Interactor::Contracts
+
+        assures do
+          required(:bar).filled
+        end
+
+        on_breach do |breaches|
+          context.fail!(message: breaches.to_h)
+        end
+      end
+    end
+
+    subject { klass.call({}) }
+
+    it 'validates the output' do
+      expect(subject).to be_a_failure
+      expect(subject.message).to eq(bar: ['bar is missing'])
+    end
+  end
+
+  describe '.promises' do
     subject(:interactor_call) { klass.call(context) }
 
     let(:parent) do
@@ -105,7 +129,7 @@ RSpec.describe Interactor::Contracts::DSL do
         include Interactor
         include Interactor::Contracts
 
-        assures do
+        promises do
           required(:bar).filled
         end
 
@@ -142,7 +166,7 @@ RSpec.describe Interactor::Contracts::DSL do
     context 'when more than one child' do
       let!(:child) do
         Class.new(parent) do
-          assures do
+          promises do
             required(:foo).filled
           end
         end
@@ -150,7 +174,7 @@ RSpec.describe Interactor::Contracts::DSL do
 
       let!(:other_child) do
         Class.new(parent) do
-          assures do
+          promises do
             required(:buzz).filled
           end
         end

--- a/spec/interactor/contracts_spec.rb
+++ b/spec/interactor/contracts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Interactor::Contracts do
       include Interactor
       include Interactor::Contracts
 
-      assures do
+      promises do
         required(:name).filled
       end
     end
@@ -29,13 +29,13 @@ RSpec.describe Interactor::Contracts do
     expect(result.name).to eq(['name is missing'])
   end
 
-  describe '.assures' do
+  describe '.promises' do
     it 'works on Interactor::Context objects' do
       interactor = Class.new do
         include Interactor
         include Interactor::Contracts
 
-        assures do
+        promises do
           required(:name).filled
         end
 
@@ -53,7 +53,7 @@ RSpec.describe Interactor::Contracts do
         include Interactor
         include Interactor::Contracts
 
-        assures do
+        promises do
           required(:name).filled
         end
 
@@ -71,11 +71,11 @@ RSpec.describe Interactor::Contracts do
         include Interactor
         include Interactor::Contracts
 
-        assures do
+        promises do
           required(:first_name).filled
         end
 
-        assures do
+        promises do
           required(:last_name).filled
         end
 
@@ -91,16 +91,16 @@ RSpec.describe Interactor::Contracts do
       expect(interactor.call(enabled?: false)).to be_a_failure
     end
 
-    it 'only validates the assurances once when defined separately' do
+    it 'only validates the promises once when defined separately' do
       interactor = Class.new do
         include Interactor
         include Interactor::Contracts
 
-        assures do
+        promises do
           required(:first_name).filled
         end
 
-        assures do
+        promises do
           required(:last_name).filled
         end
 
@@ -197,7 +197,7 @@ RSpec.describe Interactor::Contracts do
         include Interactor
         include Interactor::Contracts
 
-        assures { required(:name).filled }
+        promises { required(:name).filled }
 
         on_breach { |_| context[:message] = 'Bilbo Baggins!' }
       end


### PR DESCRIPTION
This is a term that is more likely to be immediately understood by
programmers so is a great change suggested by @KelseyDH.

Closes #25